### PR TITLE
BUGFIX: Fix support for embedded objects with embed 4

### DIFF
--- a/src/Models/EmbeddedObject.php
+++ b/src/Models/EmbeddedObject.php
@@ -89,10 +89,10 @@ class EmbeddedObject extends DataObject
     public function setFromEmbed($info)
     {
         $this->Title = $info->title;
-        $this->SourceURL = $info->url;
+        $this->SourceURL = $info->url->__toString();
         $this->Width = $info->code->width;
         $this->Height = $info->code->height;
-        $this->ThumbURL = $info->image;
+        $this->ThumbURL = $info->image->__toString();
         $this->Description = $info->description ? $info->description : $info->Title;
         $this->Type = $info->providerName;
         $embed = $info->code->html;

--- a/src/Models/EmbeddedObject.php
+++ b/src/Models/EmbeddedObject.php
@@ -94,7 +94,7 @@ class EmbeddedObject extends DataObject
         $this->Height = $info->code->height;
         $this->ThumbURL = $info->image->__toString();
         $this->Description = $info->description ? $info->description : $info->Title;
-        $this->Type = $info->providerName;
+        $this->Type = $info->getOEmbed()->get('type');
         $embed = $info->code->html;
         $this->EmbedHTML = $embed ? $embed : $this->EmbedHTML;
     }


### PR DESCRIPTION
# Scenario
We are using this forked module with the EmbeddedObject functionality where we have a feature block with a `'FeatureVideo' => EmbeddedObject::class` has_one relationship. When we save the block it throws an internal system error with the following details:
`Uncaught Exception InvalidArgumentException: "DataObject::setField: passed an object that is not a DBField" at /var/www/mysite/www/vendor/silverstripe/framework/src/ORM/DataObject.php line 2887 {"exception":"[object] (InvalidArgumentException(code: 0): DataObject::setField: passed an object that is not a DBField at /var/www/mysite/www/vendor/silverstripe/framework/src/ORM/DataObject.php:2887)"} []`

# Issue and fix
I've looked into the code and it seems that when attempting to save the embedded object the info->url call (see https://github.com/silverstripeltd/silverstripe-linkable/commit/4a84df31002e44461750768508e85fdef618f2a7#diff-6eff5b8a20272c6b9d001a62643fad8fb9b01f876438224951f2eb7dd8f4f013R92) resolves as a guzzle uri object, whereas it should be url string that we can save into the database field. Here it looks like we can call the __toString method 
that will return a full url value that can be saved without error.

In addition, the Type value being stored on the EmbeddedObject (LinkableEmbed table) was not as expected. `info->providerName` was returning something like 'YouTube'. The video was not being rendered in the web page because in the `getTemplate` function on the EmbeddedObject class, it expects a value of 'video' in this case. I've modified the relevant line so this type is correctly set from the OEmbed object.

