### PR TITLE
Replace ajaxSubmit with $.ajax for CMS6 compatibility

### DIFF
--- a/client/dist/js/bundle.js
+++ b/client/dist/js/bundle.js
@@ -170,8 +170,8 @@ _jquery2.default.entwine('ss', function ($) {
       });
 
       this.getDialog().on('submit', 'form', function () {
-        var options = {};
-        options.success = function (response) {
+        var $form = $(this);
+        var onSuccess = function (response) {
           if ($(response).is('.field')) {
             self.getDialog().empty().dialog('close');
             self.parents('.field:first').replaceWith(response);
@@ -181,7 +181,12 @@ _jquery2.default.entwine('ss', function ($) {
           }
         };
 
-        $(this).ajaxSubmit(options);
+        $.ajax({
+          type: $form.attr('method') || 'POST',
+          url: $form.attr('action'),
+          data: $form.serialize(),
+          success: onSuccess
+        });
 
         return false;
       });

--- a/client/src/legacy/linkfield.js
+++ b/client/src/legacy/linkfield.js
@@ -53,8 +53,8 @@ $.entwine('ss', ($) => {
 
       // handle dialog form submission
       this.getDialog().on('submit', 'form', function () {
-        const options = {};
-        options.success = function (response) {
+        const $form = $(this);
+        const onSuccess = function (response) {
           if ($(response).is('.field')) {
             self.getDialog().empty().dialog('close');
             self.parents('.field:first').replaceWith(response);
@@ -64,7 +64,12 @@ $.entwine('ss', ($) => {
           }
         };
 
-        $(this).ajaxSubmit(options);
+        $.ajax({
+          type: $form.attr('method') || 'POST',
+          url: $form.attr('action'),
+          data: $form.serialize(),
+          success: onSuccess,
+        });
 
         return false;
       });


### PR DESCRIPTION
## Summary

Under CMS6, `window.jQuery.fn.ajaxSubmit` is `undefined`. The jquery-form plugin is bundled inside admin's webpack-scoped jQuery (`vendor/silverstripe/admin/client/dist/js/vendor.js`) but it isn't extended onto the page-global jQuery that this module's bundle uses.

The `LinkField` dialog submit handler at `client/src/legacy/linkfield.js` previously called `$(this).ajaxSubmit(options)`. Under CMS6 this throws a `TypeError` synchronously, never reaches the `return false;`, and the browser falls back to a native form POST, navigating away from the admin SPA to a bare, unstyled `forTemplate()` response.

### Fix

Replace the `ajaxSubmit` call with a vanilla `$.ajax` POST that serialises the form. Behaviour and success callback contract are preserved:

- Validation errors: response HTML is injected back into the dialog (error rendered inline).
- Success: field markup with `.field` class is detected; dialog empties and closes, parent field is replaced, parent form is flagged `changed`.

### Files

- `client/src/legacy/linkfield.js`: source change (+8/-3).
- `client/dist/js/bundle.js`: equivalent change hand-applied to the unminified webpack output. The module's Node-6 toolchain can't safely round-trip a rebuild on modern Node, but the dist file is structurally identical to the source so the patch is byte-faithful.

## Test plan

- [ ] On a CMS6 site, open any page that exposes a `LinkField`, click `Add Link`, fill in a Title with no Page selected, click Save. Error message should render **inline in the modal** (no full-page navigation).
- [ ] Repeat with Link Type = `URL` and a valid URL. Modal should close, parent field should show the new link with Edit/Remove buttons, page form should become dirty.
- [ ] Network panel: the submit should appear as **XHR/Fetch** (not Document).
- [ ] In console: `typeof jQuery.fn.ajaxSubmit` returns `"undefined"`, confirming the code no longer depends on it.